### PR TITLE
pip requirements file, and optimisations to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MMSR
 
-MMSR is an open source image and video super-resolution toolbox based on PyTorch. It is a part of the [open-mmlab](https://github.com/open-mmlab) project developed by [Multimedia Laboratory, CUHK](http://mmlab.ie.cuhk.edu.hk/). MMSR is based on our previous projects: [BasicSR](https://github.com/xinntao/BasicSR), [ESRGAN](https://github.com/xinntao/ESRGAN), and [EDVR](https://github.com/xinntao/EDVR).
+MMSR is an open source image and video super-resolution toolbox based on PyTorch. It is a part of the [open-mmlab](https://github.com/open-mmlab) project developed by [Multimedia Laboratory, CUHK](http://mmlab.ie.cuhk.edu.hk). MMSR is based on our previous projects: [BasicSR](https://github.com/xinntao/BasicSR), [ESRGAN](https://github.com/xinntao/ESRGAN), and [EDVR](https://github.com/xinntao/EDVR).
 
 ### Highlights
 - **A unified framework** suitable for image and video super-resolution tasks. It is also easy to adapt to other restoration tasks, e.g., deblurring, denoising, etc.
@@ -13,17 +13,15 @@ MMSR is an open source image and video super-resolution toolbox based on PyTorch
 
 ## Dependencies and Installation
 
-- Python 3 (Recommend to use [Anaconda](https://www.anaconda.com/download/#linux))
-- [PyTorch >= 1.1](https://pytorch.org/)
+- Python 3 (Recommend to use [Anaconda](https://www.anaconda.com/download))
+- [PyTorch >= 1.1](https://pytorch.org)
 - NVIDIA GPU + [CUDA](https://developer.nvidia.com/cuda-downloads)
 - [Deformable Convolution](https://arxiv.org/abs/1703.06211). We use [mmdetection](https://github.com/open-mmlab/mmdetection)'s dcn implementation. Please first compile it.
   ```
   cd ./codes/models/archs/dcn
   python setup.py develop
   ```
-- Python packages: `pip install numpy opencv-python lmdb pyyaml`
-- TensorBoard:
-  - PyTorch >= 1.1: `pip install tb-nightly future`
+- Python packages: `pip install -r requirements.txt`
 
 
 ## Dataset Preparation
@@ -39,7 +37,7 @@ Results and pre-trained models are available in the [wiki-Model Zoo](https://git
 We appreciate all contributions. Please refer to [mmdetection](https://github.com/open-mmlab/mmdetection/blob/master/CONTRIBUTING.md) for contributing guideline.
 
 **Python code style**<br/>
-We adopt [PEP8](https://www.python.org/dev/peps/pep-0008/) as the preferred code style. We use [flake8](http://flake8.pycqa.org/en/latest/) as the linter and [yapf](https://github.com/google/yapf) as the formatter. Please upgrade to the latest yapf (>=0.27.0) and refer to the [yapf configuration](.style.yapf) and [flake8 configuration](.flake8).
+We adopt [PEP8](https://python.org/dev/peps/pep-0008) as the preferred code style. We use [flake8](http://flake8.pycqa.org/en/latest) as the linter and [yapf](https://github.com/google/yapf) as the formatter. Please upgrade to the latest yapf (>=0.27.0) and refer to the [yapf configuration](.style.yapf) and [flake8 configuration](.flake8).
 
 > Before you create a PR, make sure that your code lints and is formatted by yapf.
 

--- a/codes/requirements.txt
+++ b/codes/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+opencv-python
+lmdb
+pyyaml
+tb-nightly
+future


### PR DESCRIPTION
It's best to create a pip requirements file, using pip -r requirements.txt, this will need the user to `cd` into the codes directory, or provide a direct path to the requirements.txt.

The optimizations to the README.md are to remove unnecessary characters from the URL's and to update the installation instructions to follow the requirements.txt usage.