### PR TITLE
close tb_logger after training when use_tb_logger is True

### DIFF
--- a/codes/train.py
+++ b/codes/train.py
@@ -303,7 +303,8 @@ def main():
         logger.info('Saving the final model.')
         model.save('latest')
         logger.info('End of training.')
-        tb_logger.close()
+        if opt['use_tb_logger'] and 'debug' not in opt['name']:
+            tb_logger.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When `use_tb_logger` is False, `tb_logger.close` occurs `UnboundLocalError: local variable 'tb_logger' referenced before assignment`
So `tb_logger.close` should be called when `use_tb_logger` is True