### PR TITLE
support not cached data and lmdb in video_test_dataset

### DIFF
--- a/codes/data/video_test_dataset.py
+++ b/codes/data/video_test_dataset.py
@@ -48,6 +48,9 @@ class VideoTestDataset(data.Dataset):
                     self.data_info['folder'].append(GT_name_a)
                     previous_name_a = GT_name_a
                     previous_name_b = GT_name_b
+                max_idx = int(previous_name_b) + 1
+                for i in range(max_idx):
+                    self.data_info['idx'].append('{}/{}'.format(i, max_idx))
             else:
                 subfolders_LQ = util.glob_file_list(self.LQ_root)
                 subfolders_GT = util.glob_file_list(self.GT_root)

--- a/codes/data/video_test_dataset.py
+++ b/codes/data/video_test_dataset.py
@@ -50,6 +50,9 @@ class VideoTestDataset(data.Dataset):
                 if self.cache_data:
                     self.imgs_LQ[subfolder_name] = util.read_img_seq(img_paths_LQ)
                     self.imgs_GT[subfolder_name] = util.read_img_seq(img_paths_GT)
+                else:
+                    self.imgs_LQ[subfolder_name] = img_paths_LQ
+                    self.imgs_GT[subfolder_name] = img_paths_GT
         elif opt['name'].lower() in ['vimeo90k-test']:
             pass  # TODO
         else:
@@ -63,14 +66,14 @@ class VideoTestDataset(data.Dataset):
         idx, max_idx = self.data_info['idx'][index].split('/')
         idx, max_idx = int(idx), int(max_idx)
         border = self.data_info['border'][index]
-
+        select_idx = util.index_generation(idx, max_idx, self.opt['N_frames'],
+                                           padding=self.opt['padding'])
         if self.cache_data:
-            select_idx = util.index_generation(idx, max_idx, self.opt['N_frames'],
-                                               padding=self.opt['padding'])
             imgs_LQ = self.imgs_LQ[folder].index_select(0, torch.LongTensor(select_idx))
             img_GT = self.imgs_GT[folder][idx]
         else:
-            pass  # TODO
+            imgs_LQ = util.read_img_seq(self.imgs_LQ[folder]).index_select(0, torch.LongTensor(select_idx))
+            img_GT = util.read_img_seq(self.imgs_GT[folder])[idx]
 
         return {
             'LQs': imgs_LQ,

--- a/codes/data/video_test_dataset.py
+++ b/codes/data/video_test_dataset.py
@@ -51,6 +51,11 @@ class VideoTestDataset(data.Dataset):
                 max_idx = int(previous_name_b) + 1
                 for i in range(max_idx):
                     self.data_info['idx'].append('{}/{}'.format(i, max_idx))
+                border_l = [0] * max_idx
+                for i in range(self.half_N_frames):
+                    border_l[i] = 1
+                    border_l[max_idx - i - 1] = 1
+                self.data_info['border'].extend(border_l)
             else:
                 subfolders_LQ = util.glob_file_list(self.LQ_root)
                 subfolders_GT = util.glob_file_list(self.GT_root)

--- a/codes/data/video_test_dataset.py
+++ b/codes/data/video_test_dataset.py
@@ -134,4 +134,6 @@ class VideoTestDataset(data.Dataset):
         }
 
     def __len__(self):
+        if self.data_type == 'lmdb':
+            return len(self.lmdb_paths_GT)
         return len(self.data_info['path_GT'])

--- a/codes/data/video_test_dataset.py
+++ b/codes/data/video_test_dataset.py
@@ -2,6 +2,8 @@ import os.path as osp
 import torch
 import torch.utils.data as data
 import data.util as util
+import lmdb
+import numpy as np
 
 
 class VideoTestDataset(data.Dataset):
@@ -23,7 +25,8 @@ class VideoTestDataset(data.Dataset):
         self.data_type = self.opt['data_type']
         self.data_info = {'path_LQ': [], 'path_GT': [], 'folder': [], 'idx': [], 'border': []}
         if self.data_type == 'lmdb':
-            raise ValueError('No need to use LMDB during validation/test.')
+            self.paths_GT, _ = util.get_image_paths(self.data_type, self.GT_root)
+            self.GT_env, self.LQ_env = None, None
         #### Generate data info and cache data
         self.imgs_LQ, self.imgs_GT = {}, {}
         if opt['name'].lower() in ['vid4', 'reds4']:
@@ -59,6 +62,13 @@ class VideoTestDataset(data.Dataset):
             raise ValueError(
                 'Not support video test dataset. Support Vid4, REDS4 and Vimeo90k-Test.')
 
+    def _init_lmdb(self):
+        # https://github.com/chainer/chainermn/issues/129
+        self.GT_env = lmdb.open(self.GT_root, readonly=True, lock=False, readahead=False,
+                                meminit=False)
+        self.LQ_env = lmdb.open(self.LQ_root, readonly=True, lock=False, readahead=False,
+                                meminit=False)
+
     def __getitem__(self, index):
         # path_LQ = self.data_info['path_LQ'][index]
         # path_GT = self.data_info['path_GT'][index]
@@ -68,7 +78,28 @@ class VideoTestDataset(data.Dataset):
         border = self.data_info['border'][index]
         select_idx = util.index_generation(idx, max_idx, self.opt['N_frames'],
                                            padding=self.opt['padding'])
-        if self.cache_data:
+        if self.data_type == 'lmdb':
+            if self.GT_env is None or self.LQ_env is None:
+                self._init_lmdb()
+            key = self.paths_GT[idx]
+            name_a, name_b = key.split('_')
+            center_frame_idx = int(name_b)
+            GT_size_tuple = self.opt['GT_shape']
+            LQ_size_tuple = self.opt['LQ_shape']
+            img_GT = util.read_img(self.GT_env, key, GT_size_tuple)
+            img_LQ_l = []
+            for v in select_idx:
+                img_LQ = util.read_img(self.LQ_env, '{}_{:08d}'.format(name_a, v), LQ_size_tuple)
+                img_LQ_l.append(img_LQ)
+            # stack LQ images to NHWC, N is the frame number
+            img_LQs = np.stack(img_LQ_l, axis=0)
+            # BGR to RGB, HWC to CHW, numpy to tensor
+            img_GT = img_GT[:, :, [2, 1, 0]]
+            img_LQs = img_LQs[:, :, :, [2, 1, 0]]
+            img_GT = torch.from_numpy(np.ascontiguousarray(np.transpose(img_GT, (2, 0, 1)))).float()
+            imgs_LQ = torch.from_numpy(np.ascontiguousarray(np.transpose(img_LQs,
+                                                                         (0, 3, 1, 2)))).float()
+        elif self.cache_data:
             imgs_LQ = self.imgs_LQ[folder].index_select(0, torch.LongTensor(select_idx))
             img_GT = self.imgs_GT[folder][idx]
         else:

--- a/codes/data_scripts/test_dataloader.py
+++ b/codes/data_scripts/test_dataloader.py
@@ -9,7 +9,7 @@ from utils import util  # noqa: E402
 
 
 def main():
-    dataset = 'DIV2K800_sub'  # REDS | Vimeo90K | DIV2K800_sub
+    dataset = 'DIV2K800_sub'  # REDS | Vimeo90K | DIV2K800_sub | REDS4
     opt = {}
     opt['dist'] = False
     opt['gpu_ids'] = [0]
@@ -26,12 +26,16 @@ def main():
         opt['GT_size'] = 256
         opt['LQ_size'] = 64
         opt['scale'] = 4
+        opt['GT_shape'] = [3, 720, 1280]
+        opt['LQ_shape'] = [3, 180, 320]
         opt['use_flip'] = True
         opt['use_rot'] = True
         opt['interval_list'] = [1]
         opt['random_reverse'] = False
         opt['border_mode'] = False
         opt['cache_keys'] = None
+        opt['cache_data'] = False
+        opt['padding'] = 'new_info'
         opt['data_type'] = 'lmdb'  # img | lmdb | mc
     elif dataset == 'Vimeo90K':
         opt['name'] = 'test_Vimeo90K'
@@ -82,13 +86,13 @@ def main():
         if i > 5:
             break
         print(i)
-        if dataset == 'REDS' or dataset == 'Vimeo90K':
+        if dataset == 'REDS' or dataset == 'Vimeo90K' or dataset == 'REDS4':
             LQs = data['LQs']
         else:
             LQ = data['LQ']
         GT = data['GT']
 
-        if dataset == 'REDS' or dataset == 'Vimeo90K':
+        if dataset == 'REDS' or dataset == 'Vimeo90K' or dataset == 'REDS4':
             for j in range(LQs.size(1)):
                 torchvision.utils.save_image(LQs[:, j, :, :, :],
                                              'tmp/LQ_{:03d}_{}.png'.format(i, j), nrow=nrow,

--- a/codes/options/train/train_EDVR_M.yml
+++ b/codes/options/train/train_EDVR_M.yml
@@ -32,6 +32,8 @@ datasets:
     mode: video_test
     dataroot_GT: ../datasets/REDS4/GT
     dataroot_LQ: ../datasets/REDS4/sharp_bicubic
+    GT_shape: [3, 720, 1280] # C, H, W
+    LQ_shape: [3, 180, 320] # C, H, W
     cache_data: True
     N_frames: 5
     padding: new_info


### PR DESCRIPTION
Loading all test images to memory is consuming a lot of memory and this get biggers when GPU distributed training. 
If using not cached data or lmdb in video_test_dataset, memory usage is much smaller than loading all images