### PR TITLE
fix key mismatching with LQ frames

### DIFF
--- a/codes/data/REDS_dataset.py
+++ b/codes/data/REDS_dataset.py
@@ -149,6 +149,7 @@ class REDSDataset(data.Dataset):
                 len(neighbor_list))
 
         #### get the GT image (as the center frame)
+        key = '{}_{}'.format(name_a, name_b)
         if self.data_type == 'mc':
             img_GT = self._read_img_mc_BGR(self.GT_root, name_a, name_b)
             img_GT = img_GT.astype(np.float32) / 255.


### PR DESCRIPTION
As written in #76, there is a key mismatching bug with LQ frames. This happen when `border_mode=False`.
I think this is a major issue and please review this or check #76 ASAP. 